### PR TITLE
Typos in docs

### DIFF
--- a/.nitpick/0/f/0f9fbd2bef69ba5a75504d2584cadc4c785a51772ee5854c80ac45871ed185b0/issue
+++ b/.nitpick/0/f/0f9fbd2bef69ba5a75504d2584cadc4c785a51772ee5854c80ac45871ed185b0/issue
@@ -1,0 +1,18 @@
+Component: Documentation
+Date: 2017-01-21 09:10:07
+Depends_On: 
+Duplicate_Of: 
+Fix_By: 1.2
+Owner: stephen@viles.nz
+Percent_Complete: 0
+Priority: 5
+Reported_By: stephen@viles.nz
+Resolution: None
+Seen_In_Build: 
+Severity: Trivial
+State: New
+Title: Typos in docs
+Type: Bug
+Units_of_Work: 1000
+--
+The documentation files README and repo.txt have a few minor typos.

--- a/.nitpick/config/users
+++ b/.nitpick/config/users
@@ -1,3 +1,4 @@
 
 Unassigned
 travisb@travisbrown.ca
+stephen@viles.nz

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ follow the code via whatever VCS or distribution mechanism.
 This is an abbreviated guide to configuring a Nitpick repository. For a user
 guide and tutorial you should look at docs/nitpick.html or
 http://travisbrown.ca/projects/nitpick/docs/nitpick.html. A quick look at a
-static dump of the web UI can be see at
+static dump of the web UI can be seen at
 http://travisbrown.ca/projects/nitpick/issues/index.html.
 
 The project mailing list is nitpick@travisbrown.ca and the archives and list

--- a/repo.txt
+++ b/repo.txt
@@ -2,7 +2,7 @@ The design of the nitpick repository is meant to keep the amount of manual
 merging to a minimum. Some merging will undoubtedly be necessary.
 
 To effect this every file is named after the sha256 hash of the contents and
-are referrenced as such. Within the top level .nitpick directory of the project
+is referenced as such. Within the top level .nitpick directory of the project
 there is the following structure:
 
 .nitpick/
@@ -26,7 +26,7 @@ there is the following structure:
 
 Not all indirect issue directories will exist as they are created as needed.
 
-The file formats follow a simple, easily hand editted format of some metadata
+The file formats follow a simple, easily hand edited format of some metadata
 followed by two dashes, followed by the free form data. ie.
 
 """


### PR DESCRIPTION
The documentation files README and repo.txt have a few minor typos.